### PR TITLE
Lib: file extension ignore for sourcecode of experiment

### DIFF
--- a/lib/qiskitflow/lib/models/__init__.py
+++ b/lib/qiskitflow/lib/models/__init__.py
@@ -1,3 +1,3 @@
 from .metric import Metric
 from .parameter import Parameter
-from .measurement import Measurement
+from .counts import Counts

--- a/lib/qiskitflow/lib/models/counts.py
+++ b/lib/qiskitflow/lib/models/counts.py
@@ -1,7 +1,7 @@
 from typing import Dict
 
 
-class Measurement:
+class Counts:
     def __init__(self, name: str, value: Dict[str, int]):
         """ Experiment measurement.
 
@@ -18,7 +18,7 @@ class Measurement:
             "value": self.value
         }
 
-    def __eq__(self, other: 'Measurement'):
+    def __eq__(self, other: 'Counts'):
         return self.name == other.name and self.value == other.value
 
     def __repr__(self):

--- a/lib/qiskitflow/utils/utils.py
+++ b/lib/qiskitflow/utils/utils.py
@@ -1,5 +1,37 @@
+import fnmatch
+from os.path import isdir, join
+
 from .constants import EXPERIMENTS_DIRECTORY
 
 
 def get_experiment_folder(name: str) -> str:
     return "{}/{}".format(EXPERIMENTS_DIRECTORY, name)
+
+
+def include_patterns(*patterns):
+    """ Function that can be used as shutil.copytree() ignore parameter that
+    determines which files *not* to ignore, the inverse of "normal" usage.
+
+    This is a factory function that creates a function which can be used as a
+    callable for copytree()'s ignore argument, *not* ignoring files that match
+    any of the glob-style patterns provided.
+
+    ‛patterns’ are a sequence of pattern strings used to identify the files to
+    include when copying the directory tree.
+
+    Example usage:
+
+        copytree(src_directory, dst_directory,
+                 ignore=include_patterns('*.sldasm', '*.sldprt'))
+    """
+    def _ignore_patterns(path, all_names):
+        # Determine names which match one or more patterns (that shouldn't be
+        # ignored).
+        keep = (name for pattern in patterns
+                        for name in fnmatch.filter(all_names, pattern))
+        # Ignore file names which *didn't* match any of the patterns given that
+        # aren't directory names.
+        dir_names = (name for name in all_names if isdir(join(path, name)) and name == EXPERIMENTS_DIRECTORY)
+        return set(all_names) - set(keep) - set(dir_names)
+
+    return _ignore_patterns

--- a/lib/tests/lib/test_experiment.py
+++ b/lib/tests/lib/test_experiment.py
@@ -27,7 +27,7 @@ class TestExperiment(unittest.TestCase):
             exp.write_parameter("test parameter", "test parameter value")
             exp.write_parameter("test parameter 2", "test paraeter value 2")
 
-            exp.write_measurement("measurement", {"00": 1024, "11": 0})
+            exp.write_counts("counts", {"00": 1024, "11": 0})
 
             run_id = exp.run_id
 
@@ -39,11 +39,11 @@ class TestExperiment(unittest.TestCase):
 
         self.assertEqual(len(restored.metrics), len(exp.metrics))
         self.assertEqual(len(restored.parameters), len(exp.parameters))
-        self.assertEqual(len(restored.measurements), len(exp.measurements))
+        self.assertEqual(len(restored.counts), len(exp.counts))
 
         self.assertEqual(restored.metrics, exp.metrics)
         self.assertEqual(restored.parameters, exp.parameters)
-        self.assertEqual(restored.measurements, exp.measurements)
+        self.assertEqual(restored.counts, exp.counts)
 
     def test_sourcecode_save(self):
         """ Tests saving of sourecode files. """
@@ -51,10 +51,16 @@ class TestExperiment(unittest.TestCase):
 
         with Experiment("test experiment",
                         entrypoint="entrypoint_example.py",
-                        save_path=self.resources_dir) as exp:
+                        save_path=self.resources_dir,
+                        sourcecode_dir=self.resources_dir) as exp:
             run_id = exp.run_id
 
         self.assertTrue(os.path.isfile("{}/../resources/{}/test experiment/{}/sourcecode/"
                                        "entrypoint_example.py".format(self.resources_dir,
                                                                       EXPERIMENTS_DIRECTORY,
                                                                       run_id)))
+        # should skip non pythonic files
+        self.assertFalse(os.path.isfile("{}/../resources/{}/test experiment/{}/sourcecode/"
+                                        "otherfile.txt".format(self.resources_dir,
+                                                               EXPERIMENTS_DIRECTORY,
+                                                               run_id)))


### PR DESCRIPTION
Ignores unspecified file extension during compression of soucecode.
Added new parameter for sourcecode directory specification.

Closes #25 